### PR TITLE
ci: add workflow that bumps parser in other asyncapi repos

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,32 @@
+name: Bump package version in dependent repos
+
+on:
+  #It cannot run on release event as when release is created then version is not yet bumped in package.json
+  #This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - master
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Get version from package.json before release step
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
+      - name: Get name of package from package.json
+        id: extractname
+        run: echo "::set-output name=packname::$(npm run get-name --silent)"
+      - if: startsWith(github.event.commits[0].message, ' chore(release):')
+        name: Bumping latest version of this package in other repositories
+        uses: derberg/org-projects-dependency-manager@v1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          #This is commit message and PR title for repos where this package is in dependencies
+          commit_message_prod: 'fix: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'
+          #This is commit message and PR title for repos where this package is in devDependencies
+          commit_message_dev: 'chore: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "mocha --recursive",
     "release": "semantic-release",
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
-    "get-version": "echo $npm_package_version"
+    "get-version": "echo $npm_package_version",
+    "get-name": "echo $npm_package_name"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add new bump workflow
- add get package name script
- so far looks like the raml dt parser will be bumped only in the generator

**Related issue(s)**
See also https://github.com/asyncapi/.github/issues/16