### PR TITLE
chore: change linebreak style to 0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -84,7 +84,7 @@ rules:
   space-in-parens: [2, never]
   space-unary-ops: [2, {words: true, nonwords: false}]
   wrap-regex: 2
-  linebreak-style: [2, unix]
+  linebreak-style: 0
   semi: [2, always]
   arrow-spacing: [2, {before: true, after: true}]
   no-class-assign: 2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Without this change linting on windows will fail with `Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style`