### PR TITLE
chore: remove jstoiko from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @jstoiko @smoya @asyncapi-bot-eve
+* @fmvilas @smoya @asyncapi-bot-eve


### PR DESCRIPTION
removing as the codeowner never responded and accepted invite. We know he is out of Mulesoft and AsyncAPI

https://github.com/asyncapi/raml-dt-schema-parser/issues/133